### PR TITLE
Avoid clashing with django's admin/logout url

### DIFF
--- a/loginas/urls.py
+++ b/loginas/urls.py
@@ -3,5 +3,5 @@ from loginas.views import user_login, user_logout
 
 urlpatterns = [
     url(r"^login/user/(?P<user_id>.+)/$", user_login, name="loginas-user-login"),
-    url(r"^logout/$", user_logout, name="loginas-logout"),
+    url(r"^logout/user/$", user_logout, name="loginas-logout"),
 ]


### PR DESCRIPTION
Otherwise, when logging-out of admin, I'm redirected to `LOGINAS_LOGOUT_REDIRECT_URL` even if I'm the proper user.